### PR TITLE
[0.7.1] added default value for keyField option [dev]

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ like <code>"3.14"</code> </li>
 like <code>"2024-12-31"</code> </li>
 </ul>
 
-#### SinglePartitionPartitioner
+#### DefaultPartitioner
 
 The simplest partitioner: retrieves all documents within a single partition. Suitable only for scenarios where the total number of documents 
 to retrieve is smaller than 100K. No options are required
@@ -439,12 +439,12 @@ Here is the list of supported field attributes
     <tr>
         <th>Key</th>
         <th>Description</th>
-        <th>Required</th>
+        <th>Default</th>
     </tr>
     <tr>
         <td>key</td>
         <td>Name of key field</td>
-        <td>&#9989</td>
+        <td>id</td>
     </tr>
     <tr>
         <td>nonFilterable</td>

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ ThisBuild / scmInfo := Some(
   )
 )
 
-ThisBuild / version := "0.7.0"
+ThisBuild / version := "0.7.1"
 ThisBuild / scalaVersion := scala212
 ThisBuild / compileOrder := CompileOrder.JavaThenScala
 ThisBuild / javacOptions ++= Seq(

--- a/connector/src/main/scala/io/github/dejarol/azure/search/spark/connector/write/config/SearchFieldCreationOptions.scala
+++ b/connector/src/main/scala/io/github/dejarol/azure/search/spark/connector/write/config/SearchFieldCreationOptions.scala
@@ -37,11 +37,10 @@ case class SearchFieldCreationOptions(
 
   private[write] def keyField: String = {
 
-    unsafelyGet(
-      SearchFieldCreationOptions.KEY_FIELD_CONFIG,
-      Some(WriteConfig.FIELD_OPTIONS_PREFIX),
-      None
-    )
+    get(SearchFieldCreationOptions.KEY_FIELD_CONFIG) match {
+      case Some(value) => value
+      case None => SearchFieldCreationOptions.DEFAULT_KEY_FIELD_CONFIG_VALUE
+    }
   }
 
   /**
@@ -189,6 +188,7 @@ case class SearchFieldCreationOptions(
 object SearchFieldCreationOptions {
 
   final val KEY_FIELD_CONFIG = "key"
+  final val DEFAULT_KEY_FIELD_CONFIG_VALUE = "id"
   final val NON_FILTERABLE_CONFIG = "nonFilterable"
   final val NON_SORTABLE_CONFIG = "nonSortable"
   final val HIDDEN_FIELDS_CONFIG = "hidden"

--- a/connector/src/test/scala/io/github/dejarol/azure/search/spark/connector/write/config/SearchFieldCreationOptionsSpec.scala
+++ b/connector/src/test/scala/io/github/dejarol/azure/search/spark/connector/write/config/SearchFieldCreationOptionsSpec.scala
@@ -17,6 +17,24 @@ class SearchFieldCreationOptionsSpec
   private lazy val analyzerType = SearchFieldAnalyzerType.ANALYZER
 
   /**
+   * Create an instance of [[SearchFieldCreationOptions]]
+   * @param config raw configuration map
+   * @param indexActionColumn index action column
+   * @return an instance for testing
+   */
+
+  private def createInstance(
+                              config: Map[String, String],
+                              indexActionColumn: Option[String]
+                            ): SearchFieldCreationOptions = {
+
+    SearchFieldCreationOptions(
+      new SearchConfig(config),
+      indexActionColumn
+    )
+  }
+
+  /**
    * Create a map with keys being all values from enum [[SearchFieldFeature]], and values the given list of string
    * @param fields list of field names
    * @return a map for enabling/disabling all defined features for given fields
@@ -54,10 +72,7 @@ class SearchFieldCreationOptionsSpec
       case (key, Some(values)) => (key, values.mkString(","))
     }
 
-    SearchFieldCreationOptions(
-      new SearchConfig(featuresMap),
-      indexActionColumn
-    )
+    createInstance(featuresMap, indexActionColumn)
   }
 
   /**
@@ -107,19 +122,31 @@ class SearchFieldCreationOptionsSpec
 
   private def createAnalyzerOptions(analyzerConfigs: Seq[AnalyzerConfig]): SearchFieldCreationOptions = {
 
-    SearchFieldCreationOptions(
-      new SearchConfig(
-        Map(
-          SearchFieldCreationOptions.KEY_FIELD_CONFIG -> "key",
-          SearchFieldCreationOptions.ANALYZERS_CONFIG -> writeValueAs[Seq[AnalyzerConfig]](analyzerConfigs)
-        )
-      ),
-      None
+    val analyzerConfig = Map(
+      SearchFieldCreationOptions.KEY_FIELD_CONFIG -> "key",
+      SearchFieldCreationOptions.ANALYZERS_CONFIG -> writeValueAs[Seq[AnalyzerConfig]](analyzerConfigs)
     )
+
+    createInstance(analyzerConfig, None)
   }
 
   describe(anInstanceOf[SearchFieldCreationOptions]) {
     describe(SHOULD) {
+      it("retrieve user-defined key field or a default value") {
+
+        // user-defined key field
+        val keyField = "uuid"
+        createInstance(
+          Map(
+            SearchFieldCreationOptions.KEY_FIELD_CONFIG -> keyField
+          ),
+          None
+        ).keyField shouldBe keyField
+
+        // default key field
+        createInstance(Map.empty, None).keyField shouldBe SearchFieldCreationOptions.DEFAULT_KEY_FIELD_CONFIG_VALUE
+      }
+
       it("not include index action column") {
 
         val schema = Seq(


### PR DESCRIPTION
Main changes

- during write, option 'fieldOptions.keyField' is no more required as a default value (id) is provided